### PR TITLE
Fixed spelling of 'rationale'

### DIFF
--- a/SEP-0001.md
+++ b/SEP-0001.md
@@ -59,5 +59,5 @@ A short description of the SEP including a statement of the problem the SEP is s
 # Detailed Description
 If this is a standard SEP this section should contain usage examples.
 
-# Decision Rational
+# Decision Rationale
 This is a great idea because...

--- a/SEP-0003.md
+++ b/SEP-0003.md
@@ -104,5 +104,5 @@ def _private_wrapper_function(length_meters):
 * [Discussion of usage of quantities on Astropy mailing list](https://groups.google.com/forum/#!topic/astropy-dev/ZDRZNUiOPBM/discussio)
 * [An example of docs of a function using Quantities](https://gammapy.readthedocs.org/en/latest/api/gammapy.spectrum.cosmic_ray_flux.html#gammapy.spectrum.cosmic_ray_flux)
 
-# Decision Rational
+# Decision Rationale
 This SEP was accepted unanimously by the SunPy board on 9-Jun-2014 because everyone knows that units are important except for computer code...until now!

--- a/SEP-template.md
+++ b/SEP-template.md
@@ -13,5 +13,5 @@ A short description of the SEP including a statement of the problem the SEP is s
 # Detailed Description
 If this is a standard SEP this section should contain usage examples.
 
-# Decision Rational
+# Decision Rationale
 This is a great idea because...


### PR DESCRIPTION
This involves editing the template, SEP-0001 (which contains the template), and SEP-0003.

Open SEPs (PRs #6, #10, and #14) also have this spelling error.
