### PR TITLE
Board Membership and lead developer SEP

### DIFF
--- a/SEP-0002.md
+++ b/SEP-0002.md
@@ -1,8 +1,8 @@
-* author: Steven Christe 
-* contact email: 
+* author: Steven Christe
+* contact email:
 * date-creation: 2014/02/16
-* date-last-revision: 2014/06/09 
-* type: process 
+* date-last-revision: 2014/06/09
+* type: process
 * status: accepted
 
 # Abstract
@@ -23,10 +23,10 @@ open-source solar data-analysis software based on the scientific
 Python environment*. This includes but is not limited to the following
 tasks
 
-* developing the SunPy software library 
+* developing the SunPy software library
 * manage and protect the SunPy
-brand and identity 
-* promote SunPy to the community 
+brand and identity
+* promote SunPy to the community
 * managing SunPy assets, i.e. github account, domain name etc.
 
 The organization consists of an executive director, a board, and the
@@ -83,7 +83,7 @@ present shall be the act of the board.
 
 * **Absentee Voting**:  Voting by proxy is not allowed.
 An act of the board may allow for a vote to take place by correspondence
-(e.g., email). A time window of at least a week must be provided for votes to 
+(e.g., email). A time window of at least a week must be provided for votes to
 be cast and a quorum will be defined by the number of votes cast.
 
 * **Hung Board Decisions**: On the occasion of a tie, the board chair
@@ -149,18 +149,20 @@ Initially, a 2-year term is defined to expire on December 31, 2016 and
 a 1-year term is defined to expire on December 31, 2015.  Initial
 member of the board shall be (with term length in parentheses):
 
-1. Steven Christe (2 year) 
-2. Jack Ireland (2 year) 
-3. Stuart Mumford (1 year) 
-4. David Perez-Suarez (2 year) 
-5. Albert Shih (2 year) 
-6. Russell Hewett (1 year) 
+1. Steven Christe (2 year)
+2. Jack Ireland (2 year)
+3. Stuart Mumford (1 year)
+4. David Perez-Suarez (2 year)
+5. Albert Shih (2 year)
+6. Russell Hewett (1 year)
 7. Andrew Inglis (1 year)
 
+For an up to date list of board members see SEP-0006.
+
 ## References
-* http://form1023.org/how-to-draft-nonprofit-bylaws-with-examples 
+* http://form1023.org/how-to-draft-nonprofit-bylaws-with-examples
 * http://www.python.org/dev/peps/pep-0001/#pep-review-resolution
 
 # Decision Rationale
-Voted on and approved at the 2nd SunPy organisation meeting (which took place on 
+Voted on and approved at the 2nd SunPy organisation meeting (which took place on
 17-Mar-2014), approved by all present (the members of the initial board).

--- a/SEP-0002.md
+++ b/SEP-0002.md
@@ -140,6 +140,8 @@ The ED shall have ownership privileges to the sunpy github
 organization. The ED shall hold regular meetings with the developer
 community (developer meeting).
 
+The current Executive Director is named in SEP-0006.
+
 ## The Advisory Board
 The board or executive director may appoint an advisory board to
 advise the board and executive director.

--- a/SEP-0006.md
+++ b/SEP-0006.md
@@ -8,12 +8,14 @@
 # Abstract
 The purpose of this document is contains the membership information of
 the SunPy board, including names as well as membership start, and expiration
-date and board roles. Additionally this document will name the Lead developer.
+date and board roles. Additionally this document will name the current Executive
+Director.
 
 # Detailed Description
 There is no official place to list the current membership of the SunPy board
-or the lead developer. This document shall be referenced by the board founding document (SEP-00001).
-This information shall be posted on the official sunpy website for added transparency.
+or the lead developer. This document shall be referenced to by the sunpy board
+founding document (SEP-00002) and this information shall also be posted on the
+official sunpy website for added transparency.
 
 # Board Membership
 The SunPy board is composed of the following members (in alphabetical order)
@@ -32,8 +34,8 @@ The SunPy board is composed of the following members (in alphabetical order)
 | Albert Shih                   |                   | 17 Mar 2014 | 31 Dec 2016 |
 |-------------------------------|-------------------|-------------|-------------|
 
-# Lead Developer
-The lead developer is
+# Executive Director
+The executive directory (also referred to as the lead developer) is
 
 | Name           | Start        | Expiration |
 | Stuart Mumford | 23 Sep 2015  | ???        |

--- a/SEP-0006.md
+++ b/SEP-0006.md
@@ -15,8 +15,7 @@ Director.
 # Detailed Description
 There is no official place to list the current membership of the SunPy board
 or the lead developer. This document shall be referenced to by the sunpy board
-founding document (SEP-00002) and this information shall also be posted on the
-official sunpy website for added transparency.
+founding document [SEP-0002](https://github.com/sunpy/sunpy-SEP/blob/master/SEP-0002.md) and this information shall also be posted on the official sunpy website for added transparency.
 
 # Board Membership
 The SunPy board is composed of the following members (in alphabetical order)
@@ -39,6 +38,8 @@ The SunPy board is composed of the following members (in alphabetical order)
 The executive directory (also referred to as the lead developer) is
 
 | Name           | Start        | Expiration |
-| Stuart Mumford | 23 Sep 2015  | ???        |
+|----------------|--------------|------------|
+| Stuart Mumford | 23 Sep 2015  | 23 Sep 2016|
+|----------------|--------------|------------|
 
 # Decision Rationale

--- a/SEP-0006.md
+++ b/SEP-0006.md
@@ -1,0 +1,38 @@
+* author: Steven Christe
+* contact email:
+* date-creation: 2015-09-23
+* date-last-revision: 2015-09-23
+* type: process
+* status: review
+
+# Abstract
+The purpose of this document is contains the membership information of
+the SunPy board, including names as well as membership start, and expiration
+date and board roles. Additionally this document will name the Lead developer.
+
+# Detailed Description
+There is no official place to list the current membership of the SunPy board
+or the lead developer. This document shall be referenced by the board founding document (SEP-00001).
+This information shall be posted on the official sunpy website for added transparency.
+
+# Board Membership
+The SunPy board is composed of the following members (in alphabetical order)
+
+| Name                          | Role              | Start       |  Expiration |
+|-------------------------------|-------------------|-------------|-------------|
+| Steven Christe                | Chair             | 17 Mar 2014 | 31 Dec 2016 |
+| Russell Hewett                |                   | 17 Mar 2014 | 31 Dec 2015 |
+| Andrew Inglis                 | Secretary         | 17 Mar 2014 | 31 Dec 2015 |
+| Jack Ireland                  |                   | 17 Mar 2014 | 31 Dec 2016 |
+| Stuart Mumford                |                   | 17 Mar 2014 | 31 Dec 2015 |
+| Juan Carlos Martínez Oliveros |                   |  7 Apr 2014 |  7 Apr 2015 |
+| David Perez-Suarez            | Vice-chair        | 17 Mar 2014 | 31 Dec 2016 |
+| Kevin Reardon                 |                   | 23 Sep 2015 | 23 Sep 2016 |
+| Thomas Robitaille             |                   | 16 Apr 2014 | 16 Apr 2015 |
+| Albert Shih                   |                   | 17 Mar 2014 | 31 Dec 2016 |
+
+# Lead Developer
+The lead developer is
+ * Stuart Mumford
+
+# Decision Rationale

--- a/SEP-0006.md
+++ b/SEP-0006.md
@@ -30,9 +30,12 @@ The SunPy board is composed of the following members (in alphabetical order)
 | Kevin Reardon                 |                   | 23 Sep 2015 | 23 Sep 2016 |
 | Thomas Robitaille             |                   | 16 Apr 2014 | 16 Apr 2015 |
 | Albert Shih                   |                   | 17 Mar 2014 | 31 Dec 2016 |
+|-------------------------------|-------------------|-------------|-------------|
 
 # Lead Developer
 The lead developer is
- * Stuart Mumford
+
+| Name           | Start        | Expiration |
+| Stuart Mumford | 23 Sep 2015  | ???        |
 
 # Decision Rationale

--- a/SEP-0006.md
+++ b/SEP-0006.md
@@ -40,6 +40,5 @@ The executive directory (also referred to as the lead developer) is
 | Name           | Start        | Expiration |
 |----------------|--------------|------------|
 | Stuart Mumford | 23 Sep 2015  | 23 Sep 2016|
-|----------------|--------------|------------|
 
 # Decision Rationale

--- a/SEP-0006.md
+++ b/SEP-0006.md
@@ -1,9 +1,10 @@
-* author: Steven Christe
-* contact email:
-* date-creation: 2015-09-23
-* date-last-revision: 2015-09-23
-* type: process
-* status: review
+* **author**: Steven Christe
+* **contact email**:
+* **date-creation**: 2015-09-23
+* **date-last-revision**: 2015-09-24
+* **type**: process
+* **status**: review
+* **discussion**: https://github.com/sunpy/sunpy-SEP/pull/17#discussion_r40314708
 
 # Abstract
 The purpose of this document is contains the membership information of

--- a/SEP-0006.md
+++ b/SEP-0006.md
@@ -27,10 +27,10 @@ The SunPy board is composed of the following members (in alphabetical order)
 | Andrew Inglis                 | Secretary         | 17 Mar 2014 | 31 Dec 2015 |
 | Jack Ireland                  |                   | 17 Mar 2014 | 31 Dec 2016 |
 | Stuart Mumford                |                   | 17 Mar 2014 | 31 Dec 2015 |
-| Juan Carlos Martínez Oliveros |                   |  7 Apr 2014 |  7 Apr 2015 |
+| Juan Carlos Martínez Oliveros |                   |  7 Apr 2014 | 31 Dec 2015 |
 | David Perez-Suarez            | Vice-chair        | 17 Mar 2014 | 31 Dec 2016 |
-| Kevin Reardon                 |                   | 23 Sep 2015 | 23 Sep 2016 |
-| Thomas Robitaille             |                   | 16 Apr 2014 | 16 Apr 2015 |
+| Kevin Reardon                 |                   | 23 Sep 2015 | 31 Dec 2016 |
+| Thomas Robitaille             |                   | 16 Apr 2014 | 31 Dec 2015 |
 | Albert Shih                   |                   | 17 Mar 2014 | 31 Dec 2016 |
 
 # Executive Director

--- a/SEP-0006.md
+++ b/SEP-0006.md
@@ -32,7 +32,6 @@ The SunPy board is composed of the following members (in alphabetical order)
 | Kevin Reardon                 |                   | 23 Sep 2015 | 23 Sep 2016 |
 | Thomas Robitaille             |                   | 16 Apr 2014 | 16 Apr 2015 |
 | Albert Shih                   |                   | 17 Mar 2014 | 31 Dec 2016 |
-|-------------------------------|-------------------|-------------|-------------|
 
 # Executive Director
 The executive directory (also referred to as the lead developer) is

--- a/SEP-0006.md
+++ b/SEP-0006.md
@@ -3,7 +3,7 @@
 * **date-creation**: 2015-09-23
 * **date-last-revision**: 2015-09-24
 * **type**: process
-* **status**: review
+* **status**: accepted
 * **discussion**: https://github.com/sunpy/sunpy-SEP/pull/17#discussion_r40314708
 
 # Abstract
@@ -41,3 +41,4 @@ The executive directory (also referred to as the lead developer) is
 | Stuart Mumford | 23 Sep 2015  | 23 Sep 2016|
 
 # Decision Rationale
+Accepted by a [meeting of the Board on 7-Dec-2015](https://github.com/sunpy/sunpy/wiki/Minutes-of-SunPy-Board-Meeting-12-07-15).


### PR DESCRIPTION
The purpose of this SEP is to create a record of the board membership as well as to name the lead developer. This information will also be posted on the sunpy website but this will be the foundational document.