### PR TITLE
Updates to board expiration dates

### DIFF
--- a/SEP-0006.md
+++ b/SEP-0006.md
@@ -11,15 +11,14 @@
 | status        | accepted |
 
 # Abstract
-The purpose of this document is contains the membership information of
-the SunPy board, including names as well as membership start, and expiration
-date and board roles. Additionally this document will name the current Executive
-Director.
+This document lists the membership of the SunPy board and the current Executive Developer.
 
 # Detailed Description
-There is no official place to list the current membership of the SunPy board
-or the lead developer. This document shall be referenced to by the sunpy board
-founding document [SEP-0002](https://github.com/sunpy/sunpy-SEP/blob/master/SEP-0002.md) and this information shall also be posted on the official sunpy website for added transparency.
+This document lists the membership of the SunPy board and the current Executive Developer.
+The role (if applicable), start date, and expiration date for each board member is included.
+
+This document shall be referenced by the SunPy board
+founding document [SEP-0002](https://github.com/sunpy/sunpy-SEP/blob/master/SEP-0002.md) and this information shall also be posted on the official SunPy website for added transparency.
 
 # Board Membership
 The SunPy board is composed of the following members (in alphabetical order)
@@ -27,18 +26,18 @@ The SunPy board is composed of the following members (in alphabetical order)
 | Name                          | Role              | Start       |  Expiration |
 |-------------------------------|-------------------|-------------|-------------|
 | Steven Christe                | Chair             | 17 Mar 2014 | 31 Dec 2016 |
-| Russell Hewett                |                   | 17 Mar 2014 | 31 Dec 2015 |
-| Andrew Inglis                 | Secretary         | 17 Mar 2014 | 31 Dec 2015 |
+| Russell Hewett                |                   | 17 Mar 2014 | 31 Dec 2017 |
+| Andrew Inglis                 | Secretary         | 17 Mar 2014 | 31 Dec 2017 |
 | Jack Ireland                  |                   | 17 Mar 2014 | 31 Dec 2016 |
-| Stuart Mumford                |                   | 17 Mar 2014 | 31 Dec 2015 |
-| Juan Carlos Martínez Oliveros |                   |  7 Apr 2014 | 31 Dec 2015 |
+| Stuart Mumford                |                   | 17 Mar 2014 | 31 Dec 2017 |
+| Juan Carlos Martínez Oliveros |                   |  7 Apr 2014 | 31 Dec 2017 |
 | David Perez-Suarez            | Vice-chair        | 17 Mar 2014 | 31 Dec 2016 |
 | Kevin Reardon                 |                   | 23 Sep 2015 | 31 Dec 2016 |
-| Thomas Robitaille             |                   | 16 Apr 2014 | 31 Dec 2015 |
+| Thomas Robitaille             |                   | 16 Apr 2014 | 31 Dec 2017 |
 | Albert Shih                   |                   | 17 Mar 2014 | 31 Dec 2016 |
 
 # Executive Director
-The executive directory (also referred to as the lead developer) is
+The executive director (also referred to as the lead developer) is
 
 | Name           | Start        | Expiration |
 |----------------|--------------|------------|


### PR DESCRIPTION
We had an email vote initiated on 2015 Dec 28 to renew the memberships of five board members – set to expire at the end of 2015 – for an additional two years.  It does not appear that the votes were officially tallied, but they look to be unanimous (aside from folks abstaining from voting for themselves).

This PR can be updated once we have addressed the board memberships that formally expired at the end of 2016.