### PR TITLE
Add a code of conduct as a duty of the executive director

### DIFF
--- a/SEP-0002.md
+++ b/SEP-0002.md
@@ -99,8 +99,7 @@ the vote based on his/her discretion.
 quarter at times and places fixed by the board. Board meetings shall
 provide at least one week (7) days notice. Notice of meetings shall
 specify the place, day, and hour of meeting. The purpose of the
-meeting need not be specified. The executive director shall report to
-the board at least quarterly.
+meeting need not be specified.
 
 * **Extra Meetings**:  Extra meetings of the board may be called by
 the chair or vice-chair or any two (2) members of the board.  A
@@ -138,14 +137,26 @@ ED shall serve a one year term, and can be re-elected.
 ## The Executive Director
 The role of the executive director is to manage the day to day
 operations of the SunPy organization. The executive director (ED for
-short) shall report to the board. The executive director shall have
-push privileges to the SunPy repository and can elect SunPy
-maintainers from the developer community to have the same privileges.
-The ED shall have ownership privileges to the sunpy github
-organization. The ED shall hold regular meetings with the developer
-community (developer meeting).
+short) shall:
+
+* hold regular meetings with the developer community (at least monthly)
+* make regular reports to the board (at least quarterly)
+* have push privileges to the SunPy repository
+and can delegate those privileges
+* have ownership privileges to the SunPy GitHub organization
+* create and maintain the SunPy code of conduct (see below)
 
 The current Executive Director is named in SEP-0006.
+
+### Code of Conduct
+
+The SunPy organization shall have an explicit code of conduct to state
+the norms of peer interactions, including inclusiveness and respect,
+and describe the process for dispute resolution.
+The code of conduct shall be publicly posted on the SunPy website.
+The code of conduct shall be accessible in such
+a manner as to welcome and incorporate feedback from the developer
+community (e.g., a Git respository).
 
 ## The Advisory Board
 The board or executive director may appoint an advisory board to

--- a/SEP-0002.md
+++ b/SEP-0002.md
@@ -141,8 +141,7 @@ short) shall:
 
 * hold regular meetings with the developer community (at least monthly)
 * make regular reports to the board (at least quarterly)
-* have push privileges to the SunPy repository
-and can delegate those privileges
+* have push privileges to the SunPy repository and can delegate those privileges
 * have ownership privileges to the SunPy GitHub organization
 * create and maintain the SunPy code of conduct (see below)
 
@@ -156,7 +155,7 @@ and describe the process for dispute resolution.
 The code of conduct shall be publicly posted on the SunPy website.
 The code of conduct shall be accessible in such
 a manner as to welcome and incorporate feedback from the developer
-community (e.g., a Git respository).
+community, even anonymous feedback.
 
 ## The Advisory Board
 The board or executive director may appoint an advisory board to


### PR DESCRIPTION
Here's my alternative to #20, as discussed during the board meeting on 2016 Oct 26.  Rather than having a SEP that is the actual code of conduct, we use the SEP structure to state what the code of conduct has to contain and how it needs to be presented.  It's then the responsibility of the executive director to create and maintain the code of conduct.  Comments?