### PR TITLE
Added authors to SEP-10

### DIFF
--- a/SEP-0010.md
+++ b/SEP-0010.md
@@ -1,14 +1,14 @@
 # SEP-0010 -- Vision and Mission Statement
 
-| SEP           | 10                              |
+| SEP           | 10                             |
 |---------------|--------------------------------|
-| title         | Mission and Vision Statements |
-| author(s)     | |
-| contact email |               |
-| date-creation | 2020-09-08                     |
-| type          | Informational                        |
-| discussion    |  |
-| status        |                       |
+| title         | Mission and Vision Statements  |
+| author(s)     | [Monica Bobra](https://orcid.org/0000-0002-5662-9604), [Bin Chen](https://orcid.org/0000-0002-0660-3350), [Steven Christe](https://orcid.org/0000-0001-6127-795X), [Russell Hewett](https://orcid.org/0000-0001-8944-4705), [Nabil Freij](https://orcid.org/0000-0002-6253-082X), [Stuart Mumford](https://orcid.org/0000-0003-4217-4642), [Tiago Pereira](https://orcid.org/0000-0003-4747-4329), [David Perez-Suarez](https://orcid.org/0000-0003-0784-6909), [Kevin Reardon](https://orcid.org/0000-0001-8016-0001), [Daniel F. Ryan](https://orcid.org/0000-0001-8661-3825), [Sabrina Savage](https://orcid.org/0000-0002-6172-0517) |
+| contact email |  steven.d.christe@nasa.gov    |
+| date-creation | 2020-09-08                    |
+| type          | Informational                 |
+| discussion    | [Google Doc](https://docs.google.com/document/d/1kYsVqGNMnAj2DCYVi1juC4T3fDk4scAmZoi7v_KTWS0/edit?usp=sharing)|
+| status        | Accepted                      |
 
 # Introduction
 


### PR DESCRIPTION
This adds authors to the SEP which will then be used on the DOI.

The author list is based on a looking at who had access to the google doc draft as well as a call for authors in the SunPy chat for those that contributed through other channels.
