### PR TITLE
Include dimensions property to NDCube 2 API

### DIFF
--- a/SEP-0012.md
+++ b/SEP-0012.md
@@ -97,7 +97,7 @@ The behaviour of all the methods should be described by their included docstring
 
 ```python
 
-class NDCubeABC(astropy.nddata.NDDataBase):
+class NDCubeABC(astropy.nddata.NDDataBase, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def __init__(self,
@@ -182,6 +182,13 @@ class NDCubeABC(astropy.nddata.NDDataBase):
         `pixel_n_dim` equal to the number of array dimensions in the
         `.NDCube`. The number of world dimensions should be equal to the
         number of world dimensions in ``self.wcs`` and in ``self.extra_coords`` combined.
+        """
+
+    @abc.abstractmethod
+    @property
+    def dimensions(self) -> u.Quantity:
+        """
+        The array dimensions of the cube.
         """
 
     @abc.abstractmethod


### PR DESCRIPTION
`NDCubeABC.dimensions` is part of the NDCube 2 API but was originally omitted by mistake.  This PR rectifies that.